### PR TITLE
Feature 1 - Create preference

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -6,15 +6,23 @@ class PreferencesController < ApplicationController
     @pagy, @records = pagy(@preferences)
   end
 
-  def create
-    @preference = PreferenceForm.new(args: preference_form_params)
+  def new
+    @preference = Preference.new
+  end
 
-    if @preference.valid?
-      @preference.save!
+  def create
+    @preference = current_user.preferences.new(permitted_params)
+
+    if @preference.save
       redirect_to preferences_path, notice: t('views.preferences.create_success')
     else
       render :new, status: :unprocessable_entity
     end
   end
+  
+  private
 
+  def permitted_params
+    params.require(:preference).permit(:name, :description, :restriction)
+  end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -5,4 +5,16 @@ class PreferencesController < ApplicationController
     @preferences = current_user.preferences
     @pagy, @records = pagy(@preferences)
   end
+
+  def create
+    @preference = PreferenceForm.new(args: preference_form_params)
+
+    if @preference.valid?
+      @preference.save!
+      redirect_to preferences_path, notice: t('views.preferences.create_success')
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
 end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id          :bigint           not null, primary key
+#  name        :string
+#  description :text
+#  restriction :boolean
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+class Preference < ApplicationRecord
+end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -6,8 +6,16 @@
 #  name        :string
 #  description :text
 #  restriction :boolean
+#  user_id     :bigint
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
+#
 class Preference < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,8 @@ class User < ApplicationRecord
          :recoverable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
+  has_many :preferences
+
   validates :uid, uniqueness: { scope: :provider }
   validates :email, uniqueness: true, on: :update
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
       - Description
       - Restriction
       create_preference: Create Preference
+      create_success: Preference successfully created.
       description: Description
       edit:
         description: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :users
-  resources :preferences, only: %i[index]
+  resources :preferences, only: %i[index create]
   resources :recipes, only: %i[index]
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :users
-  resources :preferences, only: %i[index create]
+  resources :preferences, only: %i[index new create]
   resources :recipes, only: %i[index]
 
   namespace :api do

--- a/db/migrate/20241011194431_create_preferences.rb
+++ b/db/migrate/20241011194431_create_preferences.rb
@@ -1,0 +1,11 @@
+class CreatePreferences < ActiveRecord::Migration[7.1]
+  def change
+    create_table :preferences do |t|
+      t.string :name
+      t.text :description
+      t.boolean :restriction
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241011194431_create_preferences.rb
+++ b/db/migrate/20241011194431_create_preferences.rb
@@ -4,6 +4,7 @@ class CreatePreferences < ActiveRecord::Migration[7.1]
       t.string :name
       t.text :description
       t.boolean :restriction
+      t.references :user, index: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_141829) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_11_194431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_141829) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "preferences", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.boolean "restriction"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "settings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,8 +96,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_11_194431) do
     t.string "name"
     t.text "description"
     t.boolean "restriction"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
   create_table "settings", force: :cascade do |t|

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id          :bigint           not null, primary key
+#  name        :string
+#  description :text
+#  restriction :boolean
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+FactoryBot.define do
+  factory :preference do
+    name { "MyString" }
+    description { "MyText" }
+    restriction { false }
+  end
+end

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -6,8 +6,13 @@
 #  name        :string
 #  description :text
 #  restriction :boolean
+#  user_id     :bigint
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
 #
 FactoryBot.define do
   factory :preference do

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id          :bigint           not null, primary key
+#  name        :string
+#  description :text
+#  restriction :boolean
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe Preference, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -6,11 +6,18 @@
 #  name        :string
 #  description :text
 #  restriction :boolean
+#  user_id     :bigint
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
 #
 require 'rails_helper'
 
 RSpec.describe Preference, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
 end

--- a/spec/requests/preferences/preference_spec.rb
+++ b/spec/requests/preferences/preference_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Preferences' do
+  describe 'GET new' do
+    subject { get new_preference_path }
+
+    context 'when logged in' do
+      let!(:user) { create(:user) }
+
+      before { sign_in user }
+  
+      it 'have http status 200' do
+        expect(subject).to eq(200)
+      end
+    end
+  end
+
+  describe 'POST create' do
+    subject { post preferences_path, params: }
+
+    context 'when logged in' do
+      let!(:user) { create(:user) }
+
+      before { sign_in user }
+
+      context 'when success' do
+        let(:params) do
+          {
+            preference: {
+              name: 'RandomName',
+              description: 'RandomDescription',
+              restriction: false
+            }
+          }
+        end
+
+        it 'creates the preference' do
+          expect { subject }.to change(Preference, :count).by(1)
+        end
+
+        it 'redirect to index' do
+          expect(subject).to redirect_to(preferences_path)
+        end
+
+        it 'have http status 302' do
+          expect(subject).to eq(302)
+        end
+      end
+
+      context 'when fails' do
+        let(:params) do
+          {
+            preference: {
+              description: 'RandomDescription',
+              restriction: false
+            }
+          }
+        end
+
+        it 'have http status 422' do
+          expect(subject).to eq(422)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Board:
https://www.notion.so/1-Create-Preference-fffb29625ca681089418fc80f8982de8?pvs=4
---
#### Description:
A user can create a new preference by specifying the following attributes: name (string), description (text), and restriction (boolean).
---
#### Tasks:
- [x] Implement the model to create a preference and save the data to the database.
- [x] Ensure that the `name`, `description`, and `restriction` attributes are correctly handled in the `preferences` table.
- [x] Implement the controller to create a preference and handle successful scenario and error scenario.
- [x] Add route for **create** action.
- [x] Write tests to verify that a preference can be successfully created and saved with the correct attributes.
---
