### PR TITLE
Feature 4 - Delete preference

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -31,6 +31,8 @@ class PreferencesController < ApplicationController
     else
       redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
     end
+  rescue ActiveRecord::RecordNotDestroyed
+    redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -27,25 +27,16 @@ class PreferencesController < ApplicationController
   def destroy
     @preference = Preference.find(params[:id])
 
-    success_message = t('views.preferences.destroy_success')
-    failure_message = t('views.preferences.destroy_failure')
-
-    if @preference.destroy!
-      redirect_to preferences_path, notice: success_message, status: :see_other
+    if @preference.destroy
+      redirect_to preferences_path, notice: t('views.preferences.destroy_success')
     else
-      handle_destroy_failure(failure_message)
+      redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
     end
-  rescue ActiveRecord::RecordNotDestroyed
-    handle_destroy_failure(failure_message)
   end
 
   private
 
   def permitted_params
     params.require(:preference).permit(:name, :description, :restriction)
-  end
-
-  def handle_destroy_failure(failure_message)
-    redirect_to preferences_path, alert: failure_message, status: :unprocessable_entity
   end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -28,6 +28,15 @@ class PreferencesController < ApplicationController
     end
   end
 
+  def update
+    @preference = Preference.find(params[:id])
+    if @preference.update(permitted_params)
+      redirect_to preferences_path, notice: t('views.preferences.update_success')
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def destroy
     @preference = Preference.find(params[:id])
 
@@ -35,13 +44,6 @@ class PreferencesController < ApplicationController
       redirect_to preferences_path, notice: t('views.preferences.destroy_success')
     else
       redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
-  
-  def update
-    @preference = Preference.find(params[:id])
-    if @preference.update(permitted_params)
-      redirect_to preferences_path, notice: t('views.preferences.update_success')
-    else
-      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -26,18 +26,26 @@ class PreferencesController < ApplicationController
 
   def destroy
     @preference = Preference.find(params[:id])
+
+    success_message = t('views.preferences.destroy_success')
+    failure_message = t('views.preferences.destroy_failure')
+
     if @preference.destroy!
-      redirect_to preferences_path, notice: t('views.preferences.destroy_success'), status: :see_other
+      redirect_to preferences_path, notice: success_message, status: :see_other
     else
-      redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
+      handle_destroy_failure(failure_message)
     end
   rescue ActiveRecord::RecordNotDestroyed
-    redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
+    handle_destroy_failure(failure_message)
   end
 
   private
 
   def permitted_params
     params.require(:preference).permit(:name, :description, :restriction)
+  end
+
+  def handle_destroy_failure(failure_message)
+    redirect_to preferences_path, alert: failure_message, status: :unprocessable_entity
   end
 end

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -24,6 +24,15 @@ class PreferencesController < ApplicationController
     end
   end
 
+  def destroy
+    @preference = Preference.find(params[:id])
+    if @preference.destroy!
+      redirect_to preferences_path, notice: t('views.preferences.destroy_success'), status: :see_other
+    else
+      redirect_to preferences_path, alert: t('views.preferences.destroy_failure'), status: :unprocessable_entity
+    end
+  end
+
   private
 
   def permitted_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,9 +103,9 @@ en:
       - Restriction
       create_preference: Create Preference
       create_success: Preference successfully created.
-      destroy_success: Preference successfully removed.
-      destroy_failure: Failed to remove the preference.
       description: Description
+      destroy_failure: Failed to remove the preference.
+      destroy_success: Preference successfully removed.
       edit:
         description: ''
         title: Edit Preference

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,8 @@ en:
       - Restriction
       create_preference: Create Preference
       create_success: Preference successfully created.
+      destroy_success: Preference successfully removed.
+      destroy_failure: Failed to remove the preference.
       description: Description
       edit:
         description: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :users
-  resources :preferences, only: %i[index new show create]
+  resources :preferences, only: %i[index new show create destroy]
   resources :recipes, only: %i[index]
 
   namespace :api do

--- a/spec/requests/preferences/preference_spec.rb
+++ b/spec/requests/preferences/preference_spec.rb
@@ -122,6 +122,19 @@ describe 'Preferences' do
         subject
         expect(response).to have_http_status(:unprocessable_entity)
       end
-    end    
+    end 
+    
+    context 'when not logged in' do
+      it 'redirects to the sign-in page' do
+        subject
+        expect(response).to redirect_to(new_user_session_path)
+      end
+  
+      it 'does not change the preference count' do
+        expect {
+          delete preference_path(preference)
+        }.not_to change(Preference, :count)
+      end
+    end
   end
 end

--- a/spec/requests/preferences/preference_spec.rb
+++ b/spec/requests/preferences/preference_spec.rb
@@ -81,4 +81,47 @@ describe 'Preferences' do
       end
     end
   end
+
+  describe 'DELETE destroy' do
+    subject { delete preference_path(preference) }
+
+    let!(:user) { create(:user) }
+    let!(:preference) { create(:preference, user_id: user.id) }
+
+    context 'when logged in' do
+      before do
+        sign_in user
+      end
+
+      it 'destroys the preference' do
+        expect {
+          delete preference_path(preference)
+        }.to change(Preference, :count).by(-1)
+      end
+
+      it 'redirects to the preferences path with a success notice' do
+        subject
+        expect(response).to redirect_to(preferences_path)
+        expect(flash[:notice]).to eq(I18n.t('views.preferences.destroy_success'))
+      end
+    end
+
+    context 'when destroy fails' do
+      before do
+        allow_any_instance_of(Preference).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+        sign_in user
+      end
+    
+      it 'does not change the preference count' do
+        expect {
+          delete preference_path(preference)
+        }.not_to change(Preference, :count)
+      end
+    
+      it 'has status unprocessable entity' do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end    
+  end
 end

--- a/spec/requests/preferences/preference_spec.rb
+++ b/spec/requests/preferences/preference_spec.rb
@@ -179,14 +179,14 @@ describe 'Preferences' do
 
       it 'destroys the preference' do
         expect {
-          delete preference_path(preference)
+          subject
         }.to change(Preference, :count).by(-1)
       end
 
       it 'redirects to the preferences path with a success notice' do
         subject
         expect(response).to redirect_to(preferences_path)
-        expect(flash[:notice]).to eq(I18n.t('views.preferences.destroy_success'))
+        expect(flash[:notice]).to eq('Preference successfully removed.')
       end
     end
 
@@ -198,7 +198,7 @@ describe 'Preferences' do
 
       it 'does not change the preference count' do
         expect {
-          delete preference_path(preference)
+          subject
         }.not_to change(Preference, :count)
       end
 
@@ -216,7 +216,7 @@ describe 'Preferences' do
 
       it 'does not change the preference count' do
         expect {
-          delete preference_path(preference)
+          subject
         }.not_to change(Preference, :count)
       end
     end

--- a/spec/requests/preferences/preference_spec.rb
+++ b/spec/requests/preferences/preference_spec.rb
@@ -111,25 +111,25 @@ describe 'Preferences' do
         allow_any_instance_of(Preference).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
         sign_in user
       end
-    
+
       it 'does not change the preference count' do
         expect {
           delete preference_path(preference)
         }.not_to change(Preference, :count)
       end
-    
+
       it 'has status unprocessable entity' do
         subject
         expect(response).to have_http_status(:unprocessable_entity)
       end
-    end 
-    
+    end
+
     context 'when not logged in' do
       it 'redirects to the sign-in page' do
         subject
         expect(response).to redirect_to(new_user_session_path)
       end
-  
+
       it 'does not change the preference count' do
         expect {
           delete preference_path(preference)

--- a/spec/requests/preferences/preference_spec.rb
+++ b/spec/requests/preferences/preference_spec.rb
@@ -108,7 +108,7 @@ describe 'Preferences' do
 
     context 'when destroy fails' do
       before do
-        allow_any_instance_of(Preference).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+        allow_any_instance_of(Preference).to receive(:destroy).and_return(false)
         sign_in user
       end
 


### PR DESCRIPTION
#### Board:
https://www.notion.so/4-Delete-Preference-fffb29625ca6815cbfbddb2acbbb3a0c?pvs=4
---
#### Description:
A user can delete an existing preference from their account.
---
#### Tasks:
- [x] Implement the logic to delete a preference at controller.
- [x] Ensure that all associated data is properly handled during deletion.
- [x] Write tests to verify that a preference can be successfully deleted.
---
