### PR TITLE
Feature 7 - Include preferences in recipe creation process

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,12 +76,6 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
-  def enabled_preferences_list
-    preferences.where(restriction: true).pluck(:name, :description).map { |name, description|
-      "- #{name}: #{description}"
-    }.join("\n")
-  end
-
   private
 
   def init_uid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,12 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def enabled_preferences_list
+    preferences.where(restriction: true).pluck(:name, :description).map { |name, description|
+      "- #{name}: #{description}"
+    }.join("\n")
+  end
+
   private
 
   def init_uid

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -40,11 +40,13 @@ class RecipeGeneratorService
     [{ role: 'system', content: prompt }]
   end
 
-  def prompt
-    enabled_preferences = user.preferences.where(restriction: true).map { |preference|
+  def enabled_preferences
+    current_user.preferences.where(restriction: true).map { |preference|
       "- #{preference.name}: #{preference.description}"
     }.join("\n")
+  end
 
+  def prompt
     <<~CONTENT
       You are an expert chef assistant that recommends food recipes. You receive a list of ingredients
       by the user and you must create a detailed recipe using those ingredients. You have to take into account#{' '}

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -40,7 +40,7 @@ class RecipeGeneratorService
     [{ role: 'system', content: prompt }]
   end
 
-  def user_preferences
+  def preferences
     user.preferences.map { |preference|
       prefix = preference.restriction ? 'RESTRICTION: ' : 'PREFERENCE: '
       "#{prefix}- #{preference.name}: #{preference.description}"
@@ -53,7 +53,7 @@ class RecipeGeneratorService
       by the user and you must create a detailed recipe using those ingredients. You have to consider
       the following restrictions and preferences when crafting the recipe:#{' '}
 
-      #{user_preferences}
+      #{preferences}
 
       Respond only with the recipe, without any extra commentary or greetings in the following JSON format.
       {

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -40,13 +40,9 @@ class RecipeGeneratorService
     [{ role: 'system', content: prompt }]
   end
 
-  def enabled_preferences
-    current_user.preferences.where(restriction: true).map { |preference|
-      "- #{preference.name}: #{preference.description}"
-    }.join("\n")
-  end
-
   def prompt
+    enabled_preferences = user.enabled_preferences_list
+
     <<~CONTENT
       You are an expert chef assistant that recommends food recipes. You receive a list of ingredients
       by the user and you must create a detailed recipe using those ingredients. You have to take into account#{' '}

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -40,13 +40,20 @@ class RecipeGeneratorService
     [{ role: 'system', content: prompt }]
   end
 
-  def prompt
-    enabled_preferences = user.enabled_preferences_list
+  def user_preferences
+    user.preferences.map { |preference|
+      prefix = preference.restriction ? 'RESTRICTION: ' : 'PREFERENCE: '
+      "#{prefix}- #{preference.name}: #{preference.description}"
+    }.join("\n")
+  end
 
+  def prompt
     <<~CONTENT
       You are an expert chef assistant that recommends food recipes. You receive a list of ingredients
-      by the user and you must create a detailed recipe using those ingredients. You have to take into account#{' '}
-      the following preferences: #{enabled_preferences}
+      by the user and you must create a detailed recipe using those ingredients. You have to consider
+      the following restrictions and preferences when crafting the recipe:#{' '}
+
+      #{user_preferences}
 
       Respond only with the recipe, without any extra commentary or greetings in the following JSON format.
       {

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -41,15 +41,15 @@ class RecipeGeneratorService
   end
 
   def prompt
-    enabled_preferences = user.preferences.where(restriction: true).map do |preference|
+    enabled_preferences = user.preferences.where(restriction: true).map { |preference|
       "- #{preference.name}: #{preference.description}"
-    end.join("\n")
+    }.join("\n")
 
     <<~CONTENT
       You are an expert chef assistant that recommends food recipes. You receive a list of ingredients
-      by the user and you must create a detailed recipe using those ingredients. You have to take into account 
+      by the user and you must create a detailed recipe using those ingredients. You have to take into account#{' '}
       the following preferences: #{enabled_preferences}
-      
+
       Respond only with the recipe, without any extra commentary or greetings in the following JSON format.
       {
         name: <Dish name>,

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -41,10 +41,16 @@ class RecipeGeneratorService
   end
 
   def prompt
+    enabled_preferences = user.preferences.where(restriction: true).map do |preference|
+      "- #{preference.name}: #{preference.description}"
+    end.join("\n")
+
     <<~CONTENT
       You are an expert chef assistant that recommends food recipes. You receive a list of ingredients
-      by the user and you must create a detailed recipe using those ingredients. Respond only with the
-      recipe, without any extra commentary or greetings in the following JSON format.
+      by the user and you must create a detailed recipe using those ingredients. You have to take into account 
+      the following preferences: #{enabled_preferences}
+      
+      Respond only with the recipe, without any extra commentary or greetings in the following JSON format.
       {
         name: <Dish name>,
         instructions: <Recipe details>


### PR DESCRIPTION
#### Board:
https://www.notion.so/7-Include-preferences-in-recipe-creation-process-fffb29625ca681f48c33d109266cda0c?pvs=4
---
#### Description:
Modify prompt from RecipeGeneratorService to include user preferences when creating a recipe.
---
#### Tasks:
- [x] Add user preferences to the prompt
---
#### Preview:
If the user have the following preferences
![image](https://github.com/user-attachments/assets/4a9f0d95-ea2d-48ce-97a7-ce28b1dabc5b)

- When the **Without oven** and **Temperature** preferences are enabled, the created dishes are cold and do not require an oven.
![image](https://github.com/user-attachments/assets/2378b241-e04c-4c0e-ad52-cf9455ab2077)

- When the **Temperature** preference is disabled the created dishes could be hot.
![image](https://github.com/user-attachments/assets/1440dd85-06d0-423c-af54-1405738082eb)

