### PR TITLE
Feature 10 - Limit User Preferences to a Maximum of 5

### DIFF
--- a/app/errors/preference_limit_exceeded.rb
+++ b/app/errors/preference_limit_exceeded.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PreferenceLimitExceeded < StandardError
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,6 @@ class User < ApplicationRecord
   def check_preferences_limit(_user)
     return unless preferences.size >= Preference::MAX_PREFERENCES
 
-    raise PreferenceLimitExceeded, t('views.users.maximum_preferences_reached', max: Preference::MAX_PREFERENCES)
+    raise PreferenceLimitExceeded, I18n.t('views.users.maximum_preferences_reached', max: Preference::MAX_PREFERENCES)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,8 +83,8 @@ class User < ApplicationRecord
   end
 
   def check_preferences_limit(_user)
-    if preferences.size >= Preference::MAX_PREFERENCES
-      raise PreferenceLimitExceeded, "You can't have more than #{Preference::MAX_PREFERENCES} preferences."
-    end
+    return unless preferences.size >= Preference::MAX_PREFERENCES
+
+    raise PreferenceLimitExceeded, "You can't have more than #{Preference::MAX_PREFERENCES} preferences."
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,6 @@ class User < ApplicationRecord
   def check_preferences_limit(_user)
     return unless preferences.size >= Preference::MAX_PREFERENCES
 
-    raise PreferenceLimitExceeded, "You can't have more than #{Preference::MAX_PREFERENCES} preferences."
+    raise PreferenceLimitExceeded, t('views.users.maximum_preferences_reached', max: Preference::MAX_PREFERENCES)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,7 @@ class User < ApplicationRecord
          :recoverable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  has_many :preferences, dependent: :destroy
+  has_many :preferences, dependent: :destroy, before_add: :check_preferences_limit
   has_many :recipes, dependent: :destroy
 
   validates :uid, uniqueness: { scope: :provider }
@@ -80,5 +80,11 @@ class User < ApplicationRecord
 
   def init_uid
     self.uid = email if uid.blank? && provider == 'email'
+  end
+
+  def check_preferences_limit(_user)
+    if preferences.size >= Preference::MAX_PREFERENCES
+      raise PreferenceLimitExceeded, "You can't have more than #{Preference::MAX_PREFERENCES} preferences."
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,7 @@ en:
       email: Email
       first_name: Name
       last_name: Last Name
+      maximum_preferences_reached: You can't have more than %{max} preferences.
       new:
         description: Get started by filling in the information below to create your new user.
         title: New User
@@ -169,4 +170,3 @@ en:
       title: Users
       update_success: User successfully updated.
       update_user: Update User
-      maximum_preferences_reached: You can't have more than %{max} preferences.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,3 +169,4 @@ en:
       title: Users
       update_success: User successfully updated.
       update_user: Update User
+      maximum_preferences_reached: You can't have more than %{max} preferences.

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -19,8 +19,6 @@
 require 'rails_helper'
 
 RSpec.describe Preference do
-  let(:user) { create(:user) }
-
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
   end

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -19,6 +19,8 @@
 require 'rails_helper'
 
 RSpec.describe Preference do
+  let(:user) { create(:user) }
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:name) }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,14 +80,15 @@ describe User do
     context 'when user has reached the maximum preferences limit' do
       before do
         Preference::MAX_PREFERENCES.times do
-          create(:preference, user: user)
+          create(:preference, user:)
         end
       end
 
       it 'raises PreferenceLimitExceeded error when adding another preference' do
         expect {
           user.preferences.create!(name: 'Extra Preference', description: 'Description')
-        }.to raise_error(PreferenceLimitExceeded, "You can't have more than #{Preference::MAX_PREFERENCES} preferences.")
+        }.to raise_error(PreferenceLimitExceeded,
+                         "You can't have more than #{Preference::MAX_PREFERENCES} preferences.")
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,6 +74,32 @@ describe User do
     end
   end
 
+  describe 'preferences limit' do
+    let!(:user) { create(:user, first_name: 'John', last_name: 'Doe') }
+
+    context 'when user has reached the maximum preferences limit' do
+      before do
+        Preference::MAX_PREFERENCES.times do
+          create(:preference, user: user)
+        end
+      end
+
+      it 'raises PreferenceLimitExceeded error when adding another preference' do
+        expect {
+          user.preferences.create!(name: 'Extra Preference', description: 'Description')
+        }.to raise_error(PreferenceLimitExceeded, "You can't have more than #{Preference::MAX_PREFERENCES} preferences.")
+      end
+    end
+
+    context 'when user has not reached the maximum preferences limit' do
+      it 'allows creating a new preference' do
+        expect {
+          user.preferences.create!(name: 'New Preference', description: 'Description')
+        }.to change(user.preferences, :count).by(1)
+      end
+    end
+  end
+
   describe '.from_social_provider' do
     context 'when user does not exist' do
       let(:params) { attributes_for(:user) }


### PR DESCRIPTION
#### Board:
https://www.notion.so/10-Limit-User-Preferences-to-a-Maximum-of-5-fffb29625ca6813b823dcee623adeea4?pvs=4
---
#### Description:
The user should be able to add preferences to their account, but the system should limit them to a maximum of 5 preferences.
---
#### Tasks:
- [x] Implement logic to restrict the number of preferences a user can create to a maximum of 5.
- [x] Ensure that the system displays an appropriate message or prevents the creation of additional preferences once the limit is reached.
- [x] Write tests to verify that the limit is enforced and that users cannot add more than 5 preferences.
---